### PR TITLE
Reboot IOP on startup if not debugging

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -11,6 +11,7 @@
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <libmc.h>
+#include <iopcontrol.h>
 
 #include "saves.h"
 #include "sfo.h"
@@ -448,6 +449,11 @@ int main(int argc, char *argv[])
 	uint32_t deltaFrameTicks = 0;
 
 	dbglogger_init_mode(TTY_LOGGER, "host:/apollo-psp.log", 0);
+#else //Only reboot if we dont need host0: Access via ps2client
+
+    SifInitRpc(0);
+    while (!SifIopReset("", 0)) {};
+    while (!SifIopSync()) {};
 #endif
 
 	// Initialize SDL functions


### PR DESCRIPTION
This cleanups the IOP (aka: PS1 CPU) memory of all the resident modules loaded when apollo ELF was launched.

Allowing apollo to load its own IRX modules without conflicts 
Example: 
> previous program loaded MCMAN, but apollo loads XMCMAN, this results in an error because XMCMAN will unload from IOP when it finds out another MCMAN is already running and the RPC server will halt when binding to an incompatible MCMAN